### PR TITLE
Multiple actions for FakeHttpHandler

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -73,7 +73,7 @@
     <Compile Include="MethodConstraint.cs" />
     <Compile Include="MethodConstraintedRouteAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="AuthHeaderManipulator.cs" />
+		<Compile Include="AuthHeaderManipulator.cs" />
     <Compile Include="Authorization.cs" />
     <Compile Include="RequestExtensions.cs" />
     <Compile Include="ResponseExtensions.cs" />

--- a/Tests/LinkTests.cs
+++ b/Tests/LinkTests.cs
@@ -34,5 +34,45 @@ namespace Archon.WebApi.Tests
 			string response = client.Send(new LinkWithResponse());
 			Assert.Equal("this is a test", response);
 		}
+
+		[Fact]
+		public void can_send_a_link_with_multiple_actions_and_parse_the_response ()
+		{
+			handler.Action = (req, c) => Task.FromResult(new HttpResponseMessage
+			{
+				Content = new StringContent("this is a test")
+			});
+
+			handler.Action = (req, c) => Task.FromResult(new HttpResponseMessage
+			{
+				Content = new StringContent("this is a test too")
+			});
+
+			string response = client.Send(new LinkWithResponse());
+			Assert.Equal("this is a test", response);
+		}
+
+		[Fact]
+		public void can_send_a_link_with_multiple_actions_and_handle_them_conditionally()
+		{
+			handler.Action = (req, c) =>
+			{
+				var uriString = req.RequestUri.AbsolutePath.ToString();
+				if (uriString.Contains("OogaBooga"))
+				{
+					return Task.FromResult(new HttpResponseMessage { Content = new StringContent("this is a test") });
+				}
+
+				return null;
+			};
+
+			handler.Action = (req, c) => Task.FromResult(new HttpResponseMessage
+			{
+				Content = new StringContent("this is a test too")
+			});
+
+			string response = client.Send(new CustomLinkWithResponse("OogaBooga"));
+			Assert.Equal("this is a test", response);
+		}
 	}
 }

--- a/Tests/Links/LinkWithResponse.cs
+++ b/Tests/Links/LinkWithResponse.cs
@@ -10,4 +10,14 @@ namespace Archon.WebApi.Tests.Links
 			return await response.Content.ReadAsStringAsync();
 		}
 	}
+
+	class CustomLinkWithResponse : CustomLink, Link<string>
+	{
+		public CustomLinkWithResponse(string uri) : base(uri) { }
+
+		public async Task<string> ParseResponseAsync(HttpResponseMessage response)
+		{
+			return await response.Content.ReadAsStringAsync();
+		}
+	}
 }

--- a/Tests/Links/PlainLink.cs
+++ b/Tests/Links/PlainLink.cs
@@ -9,4 +9,17 @@ namespace Archon.WebApi.Tests.Links
 			return new HttpRequestMessage(HttpMethod.Get, "http://example.com/");
 		}
 	}
+
+	class CustomLink : Link
+	{
+		private string uri;
+		public CustomLink(string uri)
+		{
+			this.uri = uri;
+		}
+		public HttpRequestMessage CreateRequest()
+		{
+			return new HttpRequestMessage(HttpMethod.Get, $"http://example.com/{uri}");
+		}
+	}
 }


### PR DESCRIPTION
Some test cases in the new Civicsource/Civicsoure Admin.WebApi specs [inherit fake http handler functionality](https://github.com/civicsource/civicsource/blob/master/src/CivicSource/CivicSource.Core/CivicSource.Specs/Setups/AuthSetup.cs) to handle auth token requests.

The problem is that if there are more api requests to handle, you can't just tack on handlers for those requests. 

This fix allows you to add multiple actions and will loop through those actions in order, then return the first non null response; allowing you to inherit the auth handling code, and add your own based on the test scenario. 