### PR TITLE
Reimplement the Authorization header rewriter for the Documents app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## How to Use
 
-Install via nuget, [Archon.Http](https://www.nuget.org/packages/Archon.Http/) for HTTP clients
+Install via nuget; [Archon.Http](https://www.nuget.org/packages/Archon.Http/) for HTTP clients,
 
 ```powershell
 Install-Package Archon.Http
 ```
 
-or [Archon.AspNetCore](https://www.nuget.org/packages/Archon.AspNetCore/) for ASP.NET Core MVC
+or [Archon.AspNetCore](https://www.nuget.org/packages/Archon.AspNetCore/) for ASP.NET Core MVC.
 
 ```powershell
 Install-Package Archon.AspNetCore

--- a/aspnetcore/AcceptHeaderAppBuilderExtensions.cs
+++ b/aspnetcore/AcceptHeaderAppBuilderExtensions.cs
@@ -2,11 +2,16 @@
 
 namespace Archon.AspNetCore
 {
-	public static class AcceptHeaderAppBuilderExtensions
+	public static class AppBuilderExtensions
 	{
 		public static IApplicationBuilder UseAcceptHeaderRewriter(this IApplicationBuilder app)
 		{
 			return app.UseMiddleware<AcceptHeaderMiddleware>();
+		}
+
+		public static IApplicationBuilder UseAuthHeaderRewriter(this IApplicationBuilder app)
+		{
+			return app.UseMiddleware<AuthHeaderMiddleware>();
 		}
 	}
 }

--- a/aspnetcore/AcceptHeaderAppBuilderExtensions.cs
+++ b/aspnetcore/AcceptHeaderAppBuilderExtensions.cs
@@ -4,11 +4,19 @@ namespace Archon.AspNetCore
 {
 	public static class AppBuilderExtensions
 	{
+		/// <summary>
+		/// When a query string parameter keyed by <c>accept</c> is provided in a request, this middleware
+		/// overrides the HTTP <c>Accept</c> header with the value of the first matching parameter.
+		/// </summary>
 		public static IApplicationBuilder UseAcceptHeaderRewriter(this IApplicationBuilder app)
 		{
 			return app.UseMiddleware<AcceptHeaderMiddleware>();
 		}
 
+		/// <summary>
+		/// When no <c>Authorization</c> header is provided in a request, this middleware captures the first
+		/// query string parameter keyed by <c>auth</c>, and adds the parameter's value as a <c>Bearer</c> token.
+		/// </summary>
 		public static IApplicationBuilder UseAuthHeaderRewriter(this IApplicationBuilder app)
 		{
 			return app.UseMiddleware<AuthHeaderMiddleware>();

--- a/aspnetcore/AcceptHeaderMiddleware.cs
+++ b/aspnetcore/AcceptHeaderMiddleware.cs
@@ -4,6 +4,10 @@ using Microsoft.AspNetCore.Http;
 
 namespace Archon.AspNetCore
 {
+	/// <summary>
+	/// When a query string parameter keyed by <c>accept</c> is provided in a request, this middleware
+	/// overrides the HTTP <c>Accept</c> header with the value of the first matching parameter.
+	/// </summary>
 	public class AcceptHeaderMiddleware
 	{
 		readonly RequestDelegate next;

--- a/aspnetcore/AuthHeaderMiddleware.cs
+++ b/aspnetcore/AuthHeaderMiddleware.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Archon.AspNetCore
+{
+	public class AuthHeaderMiddleware
+	{
+		private readonly RequestDelegate next;
+
+		public AuthHeaderMiddleware(RequestDelegate next)
+		{
+			this.next = next;
+		}
+
+		public async Task Invoke(HttpContext context)
+		{
+			ManipulateHeaders(context.Request);
+
+			await next(context);
+		}
+
+		private static void ManipulateHeaders(HttpRequest request)
+		{
+			if (request.Headers["Authorization"].Any())
+				return;
+
+			string authQueryValue = request.Query["auth"].FirstOrDefault();
+
+			if (!string.IsNullOrEmpty(authQueryValue))
+			{
+				request.Headers["Authorization"] = new StringValues($"Bearer {authQueryValue}");
+			}
+		}
+	}
+}

--- a/aspnetcore/AuthHeaderMiddleware.cs
+++ b/aspnetcore/AuthHeaderMiddleware.cs
@@ -5,6 +5,10 @@ using Microsoft.Extensions.Primitives;
 
 namespace Archon.AspNetCore
 {
+	/// <summary>
+	/// When no <c>Authorization</c> header is provided in a request, this middleware captures the first
+	/// query string parameter keyed by <c>auth</c>, and adds the parameter's value as a <c>Bearer</c> token.
+	/// </summary>
 	public class AuthHeaderMiddleware
 	{
 		private readonly RequestDelegate next;
@@ -26,7 +30,7 @@ namespace Archon.AspNetCore
 			if (request.Headers["Authorization"].Any())
 				return;
 
-			string authQueryValue = request.Query["auth"].FirstOrDefault();
+			string authQueryValue = request.Query["auth"];
 
 			if (!string.IsNullOrEmpty(authQueryValue))
 			{

--- a/aspnetcore/GZipResourceFilter.cs
+++ b/aspnetcore/GZipResourceFilter.cs
@@ -5,8 +5,6 @@ using Microsoft.Extensions.Primitives;
 
 namespace Archon.AspNetCore
 {
-	// TODO: Separate the server and client helpers in this project so that our web clients don't need to import frickin' ASP.NET
-	
 	/// <summary>
 	/// A filter that decompresses GZip content from HTTP requests specified as <c>Content-Encoding: gzip</c>
 	/// </summary>


### PR DESCRIPTION
This got missed when splitting Archon.Http out to server and client libraries. It's been re-added, and the usage documentation has been updated.