### PR TITLE
Flesh out features for QueryStringBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,37 @@ await response.EnsureSuccess();
 
 ## Query String Builder
 
-This class allows you to easily create query strings from multiple parameters:
+This class allows you to easily create query strings from multiple parameters using `Set`, `Append`, & `Remove`:
 
 ```csharp
 var qs = new QueryStringBuilder();
-qs.Append("hello", "world");
-qs.Append("goodbye", "loneliness");
+qs.Set("hello", "world");
+qs.Set("goodbye", "loneliness");
 
 Console.WriteLine(qs.ToString()); // ?hello=world&goodbye=loneliness
+
+qs = new QueryStringBuilder();
+qs.Set("hello", "world");
+qs.Set("hello", "universe");
+
+Console.WriteLine(qs.ToString()); // ?hello=universe
+
+qs = new QueryStringBuilder();
+qs.Append("hello", "world");
+qs.Append("hello", "universe");
+
+Console.WriteLine(qs.ToString()); // ?hello=world&hello=universe
+
+qs = new QueryStringBuilder("https://example.com/?hello=world&homer=simpson");
+qs.Set("age", "42");
+qs.Set("hello", "universe");
+
+Console.WriteLine(qs.ToString()); // https://example.com?homer=simpson&age=42&hello=universe
+
+qs = new QueryStringBuilder("https://example.com/?hello=world");
+qs.Remove("hello");
+
+Console.WriteLine(qs.ToString()); // https://example.com
 ```
 
 ## Read JSON Response

--- a/aspnetcore/aspnetcore.csproj
+++ b/aspnetcore/aspnetcore.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>Middleware and helpers to make working with ASP.NET MVC easier.</Description>
     <Authors>Archon Information Systems, LLC</Authors>
@@ -21,9 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-	  <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.1.2" />
-	  <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
-	  <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="1.1.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.1.3" />
   </ItemGroup>
 </Project>

--- a/aspnetcore/aspnetcore.csproj
+++ b/aspnetcore/aspnetcore.csproj
@@ -17,6 +17,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
+    <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aspnetcore/aspnetcore.csproj
+++ b/aspnetcore/aspnetcore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Middleware and helpers to make working with ASP.NET MVC easier.</Description>
     <Authors>Archon Information Systems, LLC</Authors>

--- a/http/QueryStringBuilder.cs
+++ b/http/QueryStringBuilder.cs
@@ -1,32 +1,99 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Archon.Http
 {
 	public class QueryStringBuilder
 	{
-		readonly List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>();
+		readonly string baseUri;
+		readonly Dictionary<string, List<string>> parameters = new Dictionary<string, List<string>>();
 
-		public bool HasAny
+		public bool HasAny => parameters.Any();
+
+		public QueryStringBuilder()
+			: this(null) { }
+
+		public QueryStringBuilder(string baseUri)
 		{
-			get { return parameters.Count > 0; }
+			this.baseUri = ParseQueryString(baseUri);
 		}
+
+		string ParseQueryString(string uri)
+		{
+			if (String.IsNullOrWhiteSpace(uri))
+				return String.Empty;
+
+			int idx = uri.IndexOf("?");
+			if (idx < 0)
+				return uri;
+
+			string uriWithoutQuery = uri.Substring(0, idx);
+			string qs = uri.Substring(idx + 1, uri.Length - idx - 1);
+
+			string[] parts = qs.Split('&');
+
+			foreach (string part in parts)
+			{
+				if (part.Contains("="))
+				{
+					string[] kv = part.Split('=');
+					Append(kv[0], kv[1]);
+				}
+				else
+				{
+					Append(part, "");
+				}
+			}
+
+			return uriWithoutQuery;
+		}
+
+		public QueryStringBuilder Set(string key) => Set(key, "");
+
+		public QueryStringBuilder Set(string key, string value)
+		{
+			parameters[key] = new List<string>() { value };
+			return this;
+		}
+
+		public QueryStringBuilder Append(string key) => Append(key, "");
 
 		public QueryStringBuilder Append(string key, string value)
 		{
-			parameters.Add(new KeyValuePair<string, string>(key, value));
+			if (!parameters.ContainsKey(key))
+				parameters.Add(key, new List<string>());
+
+			parameters[key].Add(value);
+			return this;
+		}
+
+		public QueryStringBuilder Remove(string key)
+		{
+			parameters.Remove(key);
 			return this;
 		}
 
 		public override string ToString()
 		{
-			if (!HasAny) return "";
+			if (!HasAny) return baseUri;
 
-			var q = new StringBuilder("?");
+			var q = new StringBuilder($"{baseUri}?");
 
-			foreach (var item in parameters)
+			foreach (string key in parameters.Keys)
 			{
-				q.Append($"{item.Key}={item.Value}&");
+				foreach (string value in parameters[key])
+				{
+					if (!String.IsNullOrWhiteSpace(value))
+					{
+						q.Append($"{Uri.EscapeDataString(key)}={Uri.EscapeDataString(value)}&");
+					}
+					else
+					{
+						q.Append($"{Uri.EscapeDataString(key)}&");
+					}
+				}
 			}
 
 			q.Remove(q.Length - 1, 1);

--- a/http/http.csproj
+++ b/http/http.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <Description>Extensions and helper methods that make working with HttpClient easier as an API.</Description>
     <VersionPrefix>2.0.0-beta2</VersionPrefix>
     <Authors>Archon Information Systems, LLC</Authors>
-    <TargetFrameworks>netstandard2.0;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>Archon.Http</AssemblyName>
     <RootNamespace>Archon.Http</RootNamespace>
     <PackageTags>webapi;utils;api;http;authorization</PackageTags>
@@ -22,12 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
-	
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-		<PackageReference Include="System.Security.Claims" Version="4.3.0" />
-	</ItemGroup>
-
 </Project>

--- a/http/http.csproj
+++ b/http/http.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
+    <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/CsvModelBinderTests.cs
+++ b/test/CsvModelBinderTests.cs
@@ -77,7 +77,7 @@ namespace Archon.Http.Tests
 			var items = binder.BindModel(typeof(IEnumerable<Guid>), $"this-is-not-a-valid-guid,{guid1},neither is this") as IEnumerable<Guid>;
 
 			Assert.NotNull(items);
-			Assert.Equal(1, items.Count());
+			Assert.Single(items);
 			Assert.Contains(guid1, items);
 		}
 
@@ -111,7 +111,7 @@ namespace Archon.Http.Tests
 			var items = binder.BindModel(typeof(IEnumerable<int>), "this-is-not-a-valid-int,13,neither is this") as IEnumerable<int>;
 
 			Assert.NotNull(items);
-			Assert.Equal(1, items.Count());
+			Assert.Single(items);
 			Assert.Contains(13, items);
 		}
 
@@ -132,7 +132,7 @@ namespace Archon.Http.Tests
 			var items = binder.BindModel(typeof(IEnumerable<string>), " homer.simpson  ") as IEnumerable<string>;
 
 			Assert.NotNull(items);
-			Assert.Equal(1, items.Count());
+			Assert.Single(items);
 			Assert.Equal("homer.simpson", items.Single());
 		}
 

--- a/test/QueryStringBuilderTests.cs
+++ b/test/QueryStringBuilderTests.cs
@@ -4,29 +4,33 @@ namespace Archon.Http.Tests
 {
 	public class QueryStringBuilderTests
 	{
-		readonly QueryStringBuilder qs;
-
-		public QueryStringBuilderTests()
-		{
-			qs = new QueryStringBuilder();
-		}
-
 		[Fact]
 		public void can_build_empty_query_string()
 		{
+			var qs = new QueryStringBuilder();
 			Assert.Equal("", qs.ToString());
 		}
 
 		[Fact]
 		public void can_build_query_string_with_single_item()
 		{
+			var qs = new QueryStringBuilder();
 			qs.Append("hello", "world");
 			Assert.Equal("?hello=world", qs.ToString());
 		}
 
 		[Fact]
+		public void can_build_query_string_with_single_item_without_value()
+		{
+			var qs = new QueryStringBuilder();
+			qs.Append("hello");
+			Assert.Equal("?hello", qs.ToString());
+		}
+
+		[Fact]
 		public void can_build_query_string_with_multiple_items()
 		{
+			var qs = new QueryStringBuilder();
 			qs.Append("hello", "world");
 			qs.Append("goodbye", "loneliness");
 			Assert.Equal("?hello=world&goodbye=loneliness", qs.ToString());
@@ -35,11 +39,73 @@ namespace Archon.Http.Tests
 		[Fact]
 		public void can_build_query_string_with_multiple_same_key_items()
 		{
+			var qs = new QueryStringBuilder();
 			qs.Append("hello", "world");
 			qs.Append("hello", "universe");
 			qs.Append("answer", "42");
 
 			Assert.Equal("?hello=world&hello=universe&answer=42", qs.ToString());
+		}
+
+		[Fact]
+		public void can_overwrite_query_parameters_with_set()
+		{
+			var qs = new QueryStringBuilder();
+			qs.Set("hello", "world");
+			qs.Set("hello", "universe");
+
+			Assert.Equal("?hello=universe", qs.ToString());
+		}
+
+		[Fact]
+		public void can_remove_query_parameters()
+		{
+			var qs = new QueryStringBuilder();
+			qs.Append("hello", "world");
+			qs.Append("hello", "universe");
+			qs.Append("answer", "42");
+
+			qs.Remove("hello");
+
+			Assert.Equal("?answer=42", qs.ToString());
+		}
+
+		[Fact]
+		public void can_url_encode_values()
+		{
+			var qs = new QueryStringBuilder();
+			qs.Set("hello", "myname=homer & I like cheese");
+			qs.Set("oh=hai", "nothai");
+
+			Assert.Equal("?hello=myname%3Dhomer%20%26%20I%20like%20cheese&oh%3Dhai=nothai", qs.ToString());
+		}
+
+		[Fact]
+		public void can_build_query_string_with_base_uri()
+		{
+			var qs = new QueryStringBuilder("https://example.com/");
+			qs.Append("hello", "world");
+
+			Assert.Equal("https://example.com/?hello=world", qs.ToString());
+		}
+
+		[Fact]
+		public void can_build_empty_query_string_with_base_uri()
+		{
+			var qs = new QueryStringBuilder("https://example.com/");
+			Assert.Equal("https://example.com/", qs.ToString());
+		}
+
+		[Theory]
+		[InlineData("https://example.com/?oh=hai&mynameis=what&mynameis=slimshady", "https://example.com/?oh=what&mynameis=what&mynameis=slimshady")]
+		[InlineData("https://example.com?doit", "https://example.com?doit&oh=what")]
+		[InlineData("?doit", "?doit&oh=what")]
+		public void can_parse_existing_query_string_from_base_uri(string baseUri, string expected)
+		{
+			var qs = new QueryStringBuilder(baseUri);
+			qs.Set("oh", "what");
+
+			Assert.Equal(expected, qs.ToString());
 		}
 	}
 }

--- a/test/tests.csproj
+++ b/test/tests.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
+    <NoWarn>NU5105</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/tests.csproj
+++ b/test/tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.0</TargetFramework>    
+    <TargetFramework>netcoreapp2.1</TargetFramework>    
     <AssemblyName>Archon.Http.Tests</AssemblyName>    
     <RootNamespace>Archon.Http.Tests</RootNamespace>    
     <PackageTags>webapi;utils;api;http;model binders;middleware;authorization</PackageTags>    
@@ -21,9 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Need it now in the CS security client. This also sneaks in a fix for #6.

See updated usage docs:

```csharp
var qs = new QueryStringBuilder();
qs.Set("hello", "world");
qs.Set("goodbye", "loneliness");

Console.WriteLine(qs.ToString()); // ?hello=world&goodbye=loneliness

qs = new QueryStringBuilder();
qs.Set("hello", "world");
qs.Set("hello", "universe");

Console.WriteLine(qs.ToString()); // ?hello=universe

qs = new QueryStringBuilder();
qs.Append("hello", "world");
qs.Append("hello", "universe");

Console.WriteLine(qs.ToString()); // ?hello=world&hello=universe

qs = new QueryStringBuilder("https://example.com/?hello=world&homer=simpson");
qs.Set("age", "42");
qs.Set("hello", "universe");

Console.WriteLine(qs.ToString()); // https://example.com?homer=simpson&age=42&hello=universe

qs = new QueryStringBuilder("https://example.com/?hello=world");
qs.Remove("hello");

Console.WriteLine(qs.ToString()); // https://example.com
```