### PR TITLE
Handle null content when GZipping

### DIFF
--- a/aspnetcore/aspnetcore.csproj
+++ b/aspnetcore/aspnetcore.csproj
@@ -17,7 +17,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
-    <NoWarn>NU5105</NoWarn>
+	<NoWarn>NU5105;NU5125</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/http/GZipCompressingHandler.cs
+++ b/http/GZipCompressingHandler.cs
@@ -30,7 +30,7 @@ namespace Archon.Http
 		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
 			CancellationToken cancellationToken)
 		{
-			if (verbs.Contains(request.Method))
+			if (verbs.Contains(request.Method) && request.Content != null)
 				request.Content = new GZipHttpContent(request.Content);
 
 			return base.SendAsync(request, cancellationToken);

--- a/http/http.csproj
+++ b/http/http.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
-    <NoWarn>NU5105</NoWarn>
+    <NoWarn>NU5105;NU5125</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/tests.csproj
+++ b/test/tests.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
-    <NoWarn>NU5105</NoWarn>
+	<NoWarn>NU5105;NU5125</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Just because a request is not a `GET`, don't assume that it has content.

The lack of null checking was causing a [`POST` request with no body](https://github.com/civicsource/civicsource/blob/1c70d5bacd24d72dee13762d6d424de71374feaf/mailhouse/src/Client/HttpMailhouse.cs#L225) to blow up.