### PR TITLE
Remove System.Collections.Immutable dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ project.lock.json
 .vscode
 *.suo
 *.user
+.idea

--- a/http/GZipCompressingHandler.cs
+++ b/http/GZipCompressingHandler.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
@@ -14,7 +14,7 @@ namespace Archon.Http
 	/// </summary>
 	public sealed class GZipCompressingHandler : DelegatingHandler
 	{
-		private readonly ImmutableHashSet<HttpMethod> verbs;
+		private readonly HashSet<HttpMethod> verbs;
 
 		/// <inheritdoc cref="DelegatingHandler"/>
 		/// <param name="verbsToCompress">A list of HTTP verbs to compress. Generally, only <see cref="HttpMethod.Post"/> and <see cref="HttpMethod.Put"/> are particularly useful.</param>
@@ -24,7 +24,7 @@ namespace Archon.Http
 			if (verbsToCompress.Length == 0)
 				throw new ArgumentException("Must specify at least one HTTP verb to compress", nameof(verbsToCompress));
 
-			verbs = verbsToCompress.ToImmutableHashSet();
+			verbs = new HashSet<HttpMethod>(verbsToCompress);
 		}
 
 		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,

--- a/http/http.csproj
+++ b/http/http.csproj
@@ -23,6 +23,5 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It's a pointless addition to the class since the `verbs` collection is not public; all it does is blow out the dependencies of anything that consumes the `Archon.Http` package.